### PR TITLE
Update comment on Concorde fallback

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -21,7 +21,7 @@ def get_solver_tour_genetic(points, population_size=100, num_generations=100, di
 
 
 def get_optimal_route(points, distances_matrix=None, population_size = 1000, num_generations = 300):
-    # Calculer le chemin optimal avec Concorde
+    # Try Concorde first, then fall back to the genetic solver if Concorde isn't installed
     try:
         from app_utils import get_solver_tour_concorde
         tour_indices = get_solver_tour_concorde(


### PR DESCRIPTION
## Summary
- clarify the comment before `get_solver_tour_concorde` call

## Testing
- `python backend/tests.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68489ad3a7308332bf71e06fbec4b66f