### PR TITLE
Fix SSL verify flag and JS destructuring bug

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -62,7 +62,11 @@ def get_open_route_service(api_key=None):
     except KeyError:
         sslVerify = 'true'
 
-    return OpenRouteService(api_key=api_key, proxies=proxies, verifySsl=(sslVerify.lower == 'true'))
+    return OpenRouteService(
+        api_key=api_key,
+        proxies=proxies,
+        verifySsl=(sslVerify.lower() == 'true')
+    )
 
 def calculate_route(positions, profile='foot-walking', api_key=None, num_generations=300, population_size=1000):
     ors = get_open_route_service(api_key=api_key)

--- a/frontend/src/components/MarkerInput.js
+++ b/frontend/src/components/MarkerInput.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const MarkerInput = ({ marker, onChange }) => {
-    { lat, lon, label } = marker;
+    const { lat, lon, label } = marker;
     return (
         <li>
             <label>Latitude:</label>


### PR DESCRIPTION
## Summary
- fix missing parentheses when reading SSL verification setting
- fix variable declaration in MarkerInput component

## Testing
- `python3 -m py_compile backend/app.py`
- `CI=true npm test --prefix frontend --silent` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_684898cc47e883328e579cc628431b2b